### PR TITLE
Fix ingestion parser dependency

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -24,7 +24,10 @@ def clean_summary(entry, char_limit=500):
     # 2. decode HTML entities (&amp; → &, &#39; → ')
     raw = html.unescape(raw)
     # 3. strip tags & images
-    text = BeautifulSoup(raw, "lxml").get_text(separator=" ", strip=True)
+    # Use the built in HTML parser to avoid requiring the external ``lxml``
+    # dependency. ``lxml`` is not listed in ``requirements.txt`` and using it
+    # would cause runtime errors on a fresh install.
+    text = BeautifulSoup(raw, "html.parser").get_text(separator=" ", strip=True)
     # 4. collapse multiple spaces / newlines
     text = re.sub(r"\s+", " ", text).strip()
     if not text:


### PR DESCRIPTION
## Summary
- use Python's built in HTML parser instead of lxml

## Testing
- `python ingest.py --max-per-feed 1`
- `python -m scripts.check_feeds`

------
https://chatgpt.com/codex/tasks/task_e_6854766f9cd88329951b9d396eff72ae