### PR TITLE
Fix Backlog formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Pull requests are welcome! Please:
 2. Run `pre-commit run --all-files` (coming soon).
 3. Ensure CI is green.
 
-For larger features (e.g. HTML scraping, semantic search), see \`\`\*\* → “Backlog”.\*\*
+For larger features (e.g. HTML scraping, semantic search), see **Backlog**.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix the malformed "Backlog" reference in README

## Testing
- `python -m markdown README.md > README.html`

------
https://chatgpt.com/codex/tasks/task_e_685477fa871083299084ee3457f8f549