### PR TITLE
Fix TypeError in feed repair script

### DIFF
--- a/scripts/fix_feeds.py
+++ b/scripts/fix_feeds.py
@@ -42,7 +42,7 @@ async def propose_fixes(feeds: list[dict]) -> tuple[dict[str, str], int]:
         async def handle(feed: dict):
             nonlocal broken_total
             async with sem:
-                ok = await validate_url(feed["url"], sess, strict=STRICT_CHECK, tolerate_bozo=True)
+                ok = await validate_url(feed["url"], sess, strict=STRICT_CHECK)
                 if ok:
                     return
                 broken_total += 1


### PR DESCRIPTION
## Summary
- update `validate_url` call in `fix_feeds.py` to use the supported argument list

## Testing
- `pip install -r requirements.txt`
- `pip install beautifulsoup4`
- `timeout 2s python -m scripts.fix_feeds --debug`

------
https://chatgpt.com/codex/tasks/task_e_685477fb5c28832983ef539be0e4e01c