### PR TITLE
Add roadmap doc & fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ uvicorn api:app --reload
 
 ## Roadmap
 
-The full milestone breakdown lives in [\`\`](docs/PLAN.md). Highlights:
+The full milestone breakdown lives in [PLAN.md](docs/PLAN.md). Highlights:
 
 | Stage | Focus                                        |
 | ----- | -------------------------------------------- |

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,18 @@
+# Project Roadmap
+
+This document tracks the planned milestones for Spain News API.
+
+## Milestones
+
+| Stage | Focus                                        |
+| ----- | -------------------------------------------- |
+| 1     | Repo & environment bootstrap                 |
+| 2     | Curate ≥ 40 Spanish RSS feeds (`feeds.yaml`) |
+| 3     | Async ingestion module (`ingest.py`)         |
+| 4     | SQLite schema & FTS5                         |
+| 5     | Scheduled ingestion via GitHub Actions       |
+| 6     | FastAPI `/search` endpoint                   |
+| 7     | Docker + Fly/Render deploy                   |
+| 8     | User validation & backlog                    |
+
+Further improvements such as HTML scraping or semantic search will be tracked in the backlog.


### PR DESCRIPTION
## Summary
- add missing `docs/PLAN.md` with roadmap milestones
- fix README roadmap link to point to the new file

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685477fceb3083299bd885bb51fafc3e