### PR TITLE
Add clean_summary test and CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  smoke:
+  test:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Verify Python
-        run: py -3.11 -m pip --version
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt pytest beautifulsoup4 lxml
+      - name: Run tests
+        run: python -m pytest -q

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,17 @@
+import re
+from ingest import clean_summary
+
+
+def test_clean_summary_strips_html_and_truncates():
+    entry = {
+        "summary": (
+            "<div><p>This <b>is</b> <i>HTML</i> &amp; <span>more</span>. "
+            "<img src='x.jpg'/>Another sentence with extra words.</p></div>"
+        )
+    }
+    result = clean_summary(entry, char_limit=40)
+    assert not re.search(r"<[^>]+>", result)
+    assert "&amp;" not in result
+    assert len(result) <= 41
+    if len(result) > 40:
+        assert result.endswith("…")


### PR DESCRIPTION
## Summary
- add pytest test for `clean_summary` ensuring HTML is stripped and char limit obeyed
- update CI workflow to install dependencies and run pytest

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685477fd35e88329ab8b2e49323ad9ef