### PR TITLE
Add ingestion workflow

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -1,0 +1,24 @@
+name: Ingest
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt beautifulsoup4 lxml
+      - name: Run ingestion
+        run: python ingest.py
+      - name: Archive database
+        uses: actions/upload-artifact@v4
+        with:
+          name: news-db
+          path: news.db
+


### PR DESCRIPTION
## Summary
- run RSS ingestion on a schedule or manual dispatch
- archive the resulting `news.db` artifact

## Testing
- `python -m pip install -r requirements.txt pytest beautifulsoup4 lxml`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547c99e7188329a7ef348252d71d2f